### PR TITLE
Fix nestang_primer25k project, broken by NESGamepad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changes
 
 [20.03.2024]
-- Add CHANGELOG.CHANGELOG.md
+- Add CHANGELOG.md
 - Set device in nestang_nano20k.gprj
 - Add mapLoopy.v to nestang_nano20k.gprj
 - Add mapLoopy.v to nestang_primer25k.gprj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changes
+
+[20.03.2024]
+- Add CHANGELOG.CHANGELOG.md
+- Set device in nestang_nano20k.gprj
+- Add mapLoopy.v to nestang_nano20k.gprj
+- Add mapLoopy.v to nestang_primer25k.gprj
+- Add NESGamepad.v to nestang_primer25k.gprj
+- Add guards for NESGamepad (only supported by Nano20k)
+
+# ToDo

--- a/nestang_nano20k.gprj
+++ b/nestang_nano20k.gprj
@@ -3,7 +3,7 @@
 <Project>
     <Template>FPGA</Template>
     <Version>5</Version>
-    <Device name="GW2AR-18C" pn="GW2AR-LV18QN88C7/I6">gw2ar18c-001</Device>
+    <Device name="GW2AR-18C" pn="GW2AR-LV18QN88C8/I7">gw2ar18c-000</Device>
     <FileList>
         <File path="src/tang_nano_20k/config.sv" type="file.verilog" enable="1"/>
         <File path="src/NESgamepad/NESGamepad.v" type="file.verilog" enable="1"/>
@@ -27,6 +27,7 @@
         <File path="src/hdmi2/tmds_channel.sv" type="file.verilog" enable="1"/>
         <File path="src/hw_sound.v" type="file.verilog" enable="1"/>
         <File path="src/hw_uart.v" type="file.verilog" enable="1"/>
+        <File path="src/mapLoopy.v" type="file.verilog" enable="1"/>
         <File path="src/memory_controller.v" type="file.verilog" enable="1"/>
         <File path="src/mmu.v" type="file.verilog" enable="1"/>
         <File path="src/nes.v" type="file.verilog" enable="1"/>

--- a/nestang_primer25k.gprj
+++ b/nestang_primer25k.gprj
@@ -6,6 +6,7 @@
     <Device name="GW5A-25A" pn="GW5A-LV25MG121NC1/I0">gw5a25a-002</Device>
     <FileList>
         <File path="src/tang_primer_25k/config.sv" type="file.verilog" enable="1"/>
+        <File path="src/NESgamepad/NESGamepad.v" type="file.verilog" enable="1"/>
         <File path="src/MicroCode.v" type="file.verilog" enable="1"/>
         <File path="src/apu.v" type="file.verilog" enable="1"/>
         <File path="src/autofire.v" type="file.verilog" enable="1"/>
@@ -26,6 +27,7 @@
         <File path="src/hdmi2/tmds_channel.sv" type="file.verilog" enable="1"/>
         <File path="src/hw_sound.v" type="file.verilog" enable="1"/>
         <File path="src/hw_uart.v" type="file.verilog" enable="1"/>
+        <File path="src/mapLoopy.v" type="file.verilog" enable="1"/>
         <File path="src/memory_controller.v" type="file.verilog" enable="1"/>
         <File path="src/mmu.v" type="file.verilog" enable="1"/>
         <File path="src/nes.v" type="file.verilog" enable="1"/>

--- a/src/nestang_top.sv
+++ b/src/nestang_top.sv
@@ -64,12 +64,14 @@ module nestang_top (
 
 
     // NES gamepad
+`ifdef N20K
     output NES_gamepad_data_clock,
     output NES_gampepad_data_latch,
     input NES_gampead_serial_data,
     output NES_gamepad_data_clock2,
     output NES_gampepad_data_latch2,
     input NES_gampead_serial_data2,
+`endif
 
     // HDMI TX
     output       tmds_clk_n,
@@ -216,7 +218,7 @@ UartDemux #(.FREQ(FREQ), .BAUDRATE(BAUDRATE)) uart_demux(
   wire [7:0]NES_gamepad_button_state2;
   wire NES_gamepad_data_available2;
 
-
+`ifdef N20K
   NESGamepad nes_gamepad(
 		.i_clk(clk),
         .i_rst(sys_resetn),
@@ -236,6 +238,7 @@ UartDemux #(.FREQ(FREQ), .BAUDRATE(BAUDRATE)) uart_demux(
 		.o_button_state(NES_gamepad_button_state2),
         .o_data_available(NES_gamepad_data_available2)
                         );
+`endif
 
   // Joypad handling
   always @(posedge clk) begin


### PR DESCRIPTION
Changes:
- Add CHANGELOG.md
- Set device in nestang_nano20k.gprj
- Add mapLoopy.v to nestang_nano20k.gprj
- Add mapLoopy.v to nestang_primer25k.gprj
- Add NESGamepad.v to nestang_primer25k.gprj
- Add guards for NESGamepad (only supported by Nano20k)